### PR TITLE
Using of Lombok annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,12 @@
 							<artifactId>lombok</artifactId>
 							<version>${lombok.version}</version>
 						</path>
+
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>0.2.0</version>
+						</path>
 					</annotationProcessorPaths>
 				</configuration>
 

--- a/src/main/java/com/santt4na/health_check/controller/AppointmentController.java
+++ b/src/main/java/com/santt4na/health_check/controller/AppointmentController.java
@@ -18,15 +18,11 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/appointments")
+@RequiredArgsConstructor
 public class AppointmentController {
 	
 	private final AppointmentService appointmentService;
 	private final ScheduleService scheduleService;
-	
-	public AppointmentController(AppointmentService appointmentService, ScheduleService scheduleService) {
-		this.appointmentService = appointmentService;
-		this.scheduleService = scheduleService;
-	}
 	
 	@PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<AppointmentResponseDTO> createAppointment(

--- a/src/main/java/com/santt4na/health_check/controller/AuthController.java
+++ b/src/main/java/com/santt4na/health_check/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.santt4na.health_check.dto.securityDTO.AccountCredentialsDTO;
 import com.santt4na.health_check.dto.securityDTO.TokenDTO;
 import com.santt4na.health_check.service.security.AuthService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -17,10 +18,10 @@ import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController implements AuthControllerDocs {
-	
-	@Autowired
-	private AuthService service;
+
+	private final AuthService service;
 	
 	@GetMapping("/login")
 	public String showLoginPage() {

--- a/src/main/java/com/santt4na/health_check/controller/DoctorController.java
+++ b/src/main/java/com/santt4na/health_check/controller/DoctorController.java
@@ -5,6 +5,7 @@ import com.santt4na.health_check.dto.doctorDTO.DoctorRequestDTO;
 import com.santt4na.health_check.dto.doctorDTO.DoctorResponseDTO;
 import com.santt4na.health_check.dto.doctorDTO.DoctorUpdateDTO;
 import com.santt4na.health_check.service.impl.DoctorServiceImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,10 +16,10 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/doctor")
+@RequiredArgsConstructor
 public class DoctorController implements DoctorControllerDocs{
 	
-	@Autowired
-	private DoctorServiceImpl service;
+	private final DoctorServiceImpl service;
 	
 	@GetMapping(
 		produces = {MediaType.APPLICATION_JSON_VALUE}

--- a/src/main/java/com/santt4na/health_check/controller/PatientController.java
+++ b/src/main/java/com/santt4na/health_check/controller/PatientController.java
@@ -5,6 +5,7 @@ import com.santt4na.health_check.dto.patientDTO.PatientRequestDTO;
 import com.santt4na.health_check.dto.patientDTO.PatientResponseDTO;
 import com.santt4na.health_check.dto.patientDTO.PatientUpdateDTO;
 import com.santt4na.health_check.service.impl.PatientServiceImpl;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,10 +16,9 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/patient")
+@RequiredArgsConstructor
 public class PatientController implements PatientControllerDocs{
-	
-	@Autowired
-	private PatientServiceImpl service;
+	private final PatientServiceImpl service;
 	
 	@GetMapping(
 		produces = {MediaType.APPLICATION_JSON_VALUE}

--- a/src/main/java/com/santt4na/health_check/controller/ScheduleController.java
+++ b/src/main/java/com/santt4na/health_check/controller/ScheduleController.java
@@ -6,6 +6,7 @@ import com.santt4na.health_check.dto.scheduleDTO.ScheduleResponseDTO;
 import com.santt4na.health_check.dto.scheduleDTO.ScheduleUpdateDTO;
 import com.santt4na.health_check.service.ScheduleService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -16,10 +17,10 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/schedules")
+@RequiredArgsConstructor
 public class ScheduleController implements ScheduleControllerDocs {
 	
-	@Autowired
-	private ScheduleService service;
+	private final ScheduleService service;
 	
 	@GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<ScheduleResponseDTO>> findAll() {

--- a/src/main/java/com/santt4na/health_check/entity/Appointment.java
+++ b/src/main/java/com/santt4na/health_check/entity/Appointment.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 public class Appointment implements Serializable {
 	
 	@Serial
@@ -67,15 +68,4 @@ public class Appointment implements Serializable {
 	
 	private LocalDateTime confirmedAt;
 
-	@Override
-	public boolean equals(Object o) {
-		if (o == null || getClass() != o.getClass()) return false;
-		Appointment that = (Appointment) o;
-		return Objects.equals(id, that.id) && Objects.equals(appointmentDate, that.appointmentDate) && Objects.equals(patient, that.patient) && Objects.equals(doctor, that.doctor) && Objects.equals(schedule, that.schedule) && status == that.status && cancelledBy == that.cancelledBy && Objects.equals(reason, that.reason) && Objects.equals(duration, that.duration) && Objects.equals(createdAt, that.createdAt) && Objects.equals(updatedAt, that.updatedAt) && Objects.equals(confirmedAt, that.confirmedAt);
-	}
-	
-	@Override
-	public int hashCode() {
-		return Objects.hash(id, appointmentDate, patient, doctor, schedule, status, cancelledBy, reason, duration, createdAt, updatedAt, confirmedAt);
-	}
 }

--- a/src/main/java/com/santt4na/health_check/entity/Appointment.java
+++ b/src/main/java/com/santt4na/health_check/entity/Appointment.java
@@ -14,9 +14,12 @@ import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+@Setter
+@Getter
 @Entity
 @ToString
 @AllArgsConstructor
+@NoArgsConstructor
 public class Appointment implements Serializable {
 	
 	@Serial
@@ -63,106 +66,7 @@ public class Appointment implements Serializable {
 	private LocalDateTime updatedAt;
 	
 	private LocalDateTime confirmedAt;
-	
-	public Appointment() {
-	}
-	
-	public Long getId() {
-		return id;
-	}
-	
-	public void setId(Long id) {
-		this.id = id;
-	}
-	
-	public LocalDateTime getAppointmentDate() {
-		return appointmentDate;
-	}
-	
-	public void setAppointmentDate(LocalDateTime appointmentDate) {
-		this.appointmentDate = appointmentDate;
-	}
-	
-	public Patient getPatient() {
-		return patient;
-	}
-	
-	public void setPatient(Patient patient) {
-		this.patient = patient;
-	}
-	
-	public Doctor getDoctor() {
-		return doctor;
-	}
-	
-	public void setDoctor(Doctor doctor) {
-		this.doctor = doctor;
-	}
-	
-	public Schedule getSchedule() {
-		return schedule;
-	}
-	
-	public void setSchedule(Schedule schedule) {
-		this.schedule = schedule;
-	}
-	
-	public AppointmentStatus getStatus() {
-		return status;
-	}
-	
-	public void setStatus(AppointmentStatus status) {
-		this.status = status;
-	}
-	
-	public CancelledBy getCancelledBy() {
-		return cancelledBy;
-	}
-	
-	public void setCancelledBy(CancelledBy cancelledBy) {
-		this.cancelledBy = cancelledBy;
-	}
-	
-	public String getReason() {
-		return reason;
-	}
-	
-	public void setReason(String reason) {
-		this.reason = reason;
-	}
-	
-	public Integer getDuration() {
-		return duration;
-	}
-	
-	public void setDuration(Integer duration) {
-		this.duration = duration;
-	}
-	
-	public LocalDateTime getCreatedAt() {
-		return createdAt;
-	}
-	
-	public void setCreatedAt(LocalDateTime createdAt) {
-		this.createdAt = createdAt;
-	}
-	
-	public LocalDateTime getUpdatedAt() {
-		return updatedAt;
-	}
-	
-	public void setUpdatedAt(LocalDateTime updatedAt) {
-		this.updatedAt = updatedAt;
-	}
-	
-	public LocalDateTime getConfirmedAt() {
-		return confirmedAt;
-	}
-	
-	public void setConfirmedAt(LocalDateTime confirmedAt) {
-		this.confirmedAt = confirmedAt;
-	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (o == null || getClass() != o.getClass()) return false;

--- a/src/main/java/com/santt4na/health_check/entity/Doctor.java
+++ b/src/main/java/com/santt4na/health_check/entity/Doctor.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @Setter
 @Getter
+@EqualsAndHashCode
 public class Doctor implements Serializable {
 	
 	@Serial
@@ -77,15 +78,4 @@ public class Doctor implements Serializable {
 	@UpdateTimestamp
 	private LocalDateTime updatedAt;
 
-	@Override
-	public boolean equals(Object o) {
-		if (o == null || getClass() != o.getClass()) return false;
-		Doctor doctor = (Doctor) o;
-		return Objects.equals(id, doctor.id) && Objects.equals(fullName, doctor.fullName) && Objects.equals(email, doctor.email) && gender == doctor.gender && Objects.equals(phone, doctor.phone) && specialty == doctor.specialty && Objects.equals(medicalLicense, doctor.medicalLicense) && Objects.equals(availableSchedules, doctor.availableSchedules) && Objects.equals(appointments, doctor.appointments) && Objects.equals(user, doctor.user) && Objects.equals(createdAt, doctor.createdAt) && Objects.equals(updatedAt, doctor.updatedAt);
-	}
-	
-	@Override
-	public int hashCode() {
-		return Objects.hash(id, fullName, email, gender, phone, specialty, medicalLicense, availableSchedules, appointments, user, createdAt, updatedAt);
-	}
 }

--- a/src/main/java/com/santt4na/health_check/entity/Doctor.java
+++ b/src/main/java/com/santt4na/health_check/entity/Doctor.java
@@ -22,6 +22,9 @@ import java.util.Objects;
 @Entity
 @ToString
 @AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
 public class Doctor implements Serializable {
 	
 	@Serial
@@ -73,106 +76,7 @@ public class Doctor implements Serializable {
 	
 	@UpdateTimestamp
 	private LocalDateTime updatedAt;
-	
-	public Doctor() {
-	}
-	
-	public Long getId() {
-		return id;
-	}
-	
-	public void setId(Long id) {
-		this.id = id;
-	}
-	
-	public String getFullName() {
-		return fullName;
-	}
-	
-	public void setFullName(String fullName) {
-		this.fullName = fullName;
-	}
-	
-	public String getEmail() {
-		return email;
-	}
-	
-	public void setEmail(String email) {
-		this.email = email;
-	}
-	
-	public Gender getGender() {
-		return gender;
-	}
-	
-	public void setGender(Gender gender) {
-		this.gender = gender;
-	}
-	
-	public String getPhone() {
-		return phone;
-	}
-	
-	public void setPhone(String phone) {
-		this.phone = phone;
-	}
-	
-	public Specialty getSpecialty() {
-		return specialty;
-	}
-	
-	public void setSpecialty(Specialty specialty) {
-		this.specialty = specialty;
-	}
-	
-	public String getMedicalLicense() {
-		return medicalLicense;
-	}
-	
-	public void setMedicalLicense(String medicalLicense) {
-		this.medicalLicense = medicalLicense;
-	}
-	
-	public List<Schedule> getAvailableSchedules() {
-		return availableSchedules;
-	}
-	
-	public void setAvailableSchedules(List<Schedule> availableSchedules) {
-		this.availableSchedules = availableSchedules;
-	}
-	
-	public List<Appointment> getAppointments() {
-		return appointments;
-	}
-	
-	public void setAppointments(List<Appointment> appointments) {
-		this.appointments = appointments;
-	}
-	
-	public User getUser() {
-		return user;
-	}
-	
-	public void setUser(User user) {
-		this.user = user;
-	}
-	
-	public LocalDateTime getCreatedAt() {
-		return createdAt;
-	}
-	
-	public void setCreatedAt(LocalDateTime createdAt) {
-		this.createdAt = createdAt;
-	}
-	
-	public LocalDateTime getUpdatedAt() {
-		return updatedAt;
-	}
-	
-	public void setUpdatedAt(LocalDateTime updatedAt) {
-		this.updatedAt = updatedAt;
-	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (o == null || getClass() != o.getClass()) return false;

--- a/src/main/java/com/santt4na/health_check/entity/Patient.java
+++ b/src/main/java/com/santt4na/health_check/entity/Patient.java
@@ -1,11 +1,5 @@
 package com.santt4na.health_check.entity;
 
-/*
-import com.santt4na.health_check.entity.security.User;
-import org.hibernate.proxy.HibernateProxy;
-import java.util.Objects;
-*/
-
 import com.santt4na.health_check.enums.Gender;
 import jakarta.persistence.*;
 import lombok.*;
@@ -24,6 +18,9 @@ import java.util.Objects;
 @Entity
 @ToString
 @AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
 public class Patient implements Serializable {
 	
 	@Serial
@@ -58,12 +55,6 @@ public class Patient implements Serializable {
 	@Pattern(regexp = "\\d{3}\\.?\\d{3}\\.?\\d{3}-?\\d{2}", message = "Invalid CPF format")
 	private String cpf;
 	
-	/*
-	@OneToOne
-	@JoinColumn(name = "user_id", referencedColumnName = "id", nullable = false, unique = true)
-	private User user;
-	*/
-	
 	@Size(max = 50, message = "Health insurance must not exceed 50 characters")
 	private String healthInsurance;
 	
@@ -76,97 +67,6 @@ public class Patient implements Serializable {
 	
 	@UpdateTimestamp
 	private LocalDateTime updatedAt;
-	
-	public Patient() {
-	}
-	
-	public Long getId() {
-		return id;
-	}
-	
-	public void setId(Long id) {
-		this.id = id;
-	}
-	
-	public String getEmail() {
-		return email;
-	}
-	
-	public void setEmail(String email) {
-		this.email = email;
-	}
-	
-	public String getFullName() {
-		return fullName;
-	}
-	
-	public void setFullName(String fullName) {
-		this.fullName = fullName;
-	}
-	
-	public Gender getGender() {
-		return gender;
-	}
-	
-	public void setGender(Gender gender) {
-		this.gender = gender;
-	}
-	
-	public String getPhone() {
-		return phone;
-	}
-	
-	public void setPhone(String phone) {
-		this.phone = phone;
-	}
-	
-	public LocalDate getDateOfBirth() {
-		return dateOfBirth;
-	}
-	
-	public void setDateOfBirth(LocalDate dateOfBirth) {
-		this.dateOfBirth = dateOfBirth;
-	}
-	
-	public String getCpf() {
-		return cpf;
-	}
-	
-	public void setCpf(String cpf) {
-		this.cpf = cpf;
-	}
-	
-	public String getHealthInsurance() {
-		return healthInsurance;
-	}
-	
-	public void setHealthInsurance(String healthInsurance) {
-		this.healthInsurance = healthInsurance;
-	}
-	
-	public List<Appointment> getAppointments() {
-		return appointments;
-	}
-	
-	public void setAppointments(List<Appointment> appointments) {
-		this.appointments = appointments;
-	}
-	
-	public LocalDateTime getCreatedAt() {
-		return createdAt;
-	}
-	
-	public void setCreatedAt(LocalDateTime createdAt) {
-		this.createdAt = createdAt;
-	}
-	
-	public LocalDateTime getUpdatedAt() {
-		return updatedAt;
-	}
-	
-	public void setUpdatedAt(LocalDateTime updatedAt) {
-		this.updatedAt = updatedAt;
-	}
 	
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/com/santt4na/health_check/entity/Patient.java
+++ b/src/main/java/com/santt4na/health_check/entity/Patient.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @Setter
 @Getter
+@EqualsAndHashCode
 public class Patient implements Serializable {
 	
 	@Serial
@@ -67,16 +68,4 @@ public class Patient implements Serializable {
 	
 	@UpdateTimestamp
 	private LocalDateTime updatedAt;
-	
-	@Override
-	public boolean equals(Object o) {
-		if (o == null || getClass() != o.getClass()) return false;
-		Patient patient = (Patient) o;
-		return Objects.equals(id, patient.id) && Objects.equals(email, patient.email) && Objects.equals(fullName, patient.fullName) && gender == patient.gender && Objects.equals(phone, patient.phone) && Objects.equals(dateOfBirth, patient.dateOfBirth) && Objects.equals(cpf, patient.cpf) && Objects.equals(healthInsurance, patient.healthInsurance) && Objects.equals(appointments, patient.appointments) && Objects.equals(createdAt, patient.createdAt) && Objects.equals(updatedAt, patient.updatedAt);
-	}
-	
-	@Override
-	public int hashCode() {
-		return Objects.hash(id, email, fullName, gender, phone, dateOfBirth, cpf, healthInsurance, appointments, createdAt, updatedAt);
-	}
 }

--- a/src/main/java/com/santt4na/health_check/entity/Schedule.java
+++ b/src/main/java/com/santt4na/health_check/entity/Schedule.java
@@ -1,6 +1,7 @@
 package com.santt4na.health_check.entity;
 
 import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,6 +18,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @Setter
 @Getter
+@EqualsAndHashCode
 public class Schedule implements Serializable {
 	
 	@Serial
@@ -48,17 +50,5 @@ public class Schedule implements Serializable {
 		if (!endTime.isAfter(startTime)) {
 			throw new IllegalStateException("End time must be after start time");
 		}
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (o == null || getClass() != o.getClass()) return false;
-		Schedule schedule = (Schedule) o;
-		return Objects.equals(id, schedule.id) && Objects.equals(doctor, schedule.doctor) && Objects.equals(appointments, schedule.appointments) && Objects.equals(startTime, schedule.startTime) && Objects.equals(endTime, schedule.endTime) && Objects.equals(available, schedule.available);
-	}
-	
-	@Override
-	public int hashCode() {
-		return Objects.hash(id, doctor, appointments, startTime, endTime, available);
 	}
 }

--- a/src/main/java/com/santt4na/health_check/entity/Schedule.java
+++ b/src/main/java/com/santt4na/health_check/entity/Schedule.java
@@ -1,6 +1,9 @@
 package com.santt4na.health_check.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -11,6 +14,9 @@ import java.util.Objects;
 
 @Entity
 @Table(name = "schedules")
+@NoArgsConstructor
+@Setter
+@Getter
 public class Schedule implements Serializable {
 	
 	@Serial
@@ -43,55 +49,7 @@ public class Schedule implements Serializable {
 			throw new IllegalStateException("End time must be after start time");
 		}
 	}
-	
-	public Long getId() {
-		return id;
-	}
-	
-	public void setId(Long id) {
-		this.id = id;
-	}
-	
-	public Doctor getDoctor() {
-		return doctor;
-	}
-	
-	public void setDoctor(Doctor doctor) {
-		this.doctor = doctor;
-	}
-	
-	public List<Appointment> getAppointments() {
-		return appointments;
-	}
-	
-	public void setAppointments(List<Appointment> appointments) {
-		this.appointments = appointments;
-	}
-	
-	public LocalDateTime getStartTime() {
-		return startTime;
-	}
-	
-	public void setStartTime(LocalDateTime startTime) {
-		this.startTime = startTime;
-	}
-	
-	public LocalDateTime getEndTime() {
-		return endTime;
-	}
-	
-	public void setEndTime(LocalDateTime endTime) {
-		this.endTime = endTime;
-	}
-	
-	public Boolean getAvailable() {
-		return available;
-	}
-	
-	public void setAvailable(Boolean available) {
-		this.available = available;
-	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (o == null || getClass() != o.getClass()) return false;

--- a/src/main/java/com/santt4na/health_check/service/impl/AppointmentServiceImpl.java
+++ b/src/main/java/com/santt4na/health_check/service/impl/AppointmentServiceImpl.java
@@ -21,6 +21,7 @@ import com.santt4na.health_check.repository.PatientRepository;
 import com.santt4na.health_check.repository.ScheduleRepository;
 import com.santt4na.health_check.service.AppointmentService;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,28 +32,23 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class AppointmentServiceImpl implements AppointmentService {
 	
 	private static final Logger logger = LoggerFactory.getLogger(Startup.class);
 	private static final Logger auditLogger = LoggerFactory.getLogger("audit");
 	
-	@Autowired
-	private AppointmentMapper appointmentMapper;
+	private final AppointmentMapper appointmentMapper;
 	
-	@Autowired
-	private ScheduleMapper scheduleMapper;
+	private final ScheduleMapper scheduleMapper;
 	
-	@Autowired
-	private AppointmentRepository appointmentRepository;
+	private final AppointmentRepository appointmentRepository;
 	
-	@Autowired
-	private ScheduleRepository scheduleRepository;
+	private final ScheduleRepository scheduleRepository;
 	
-	@Autowired
-	private DoctorRepository doctorRepository;
+	private final DoctorRepository doctorRepository;
 	
-	@Autowired
-	private PatientRepository patientRepository;
+	private final PatientRepository patientRepository;
 	
 	@Override
 	@Transactional

--- a/src/main/java/com/santt4na/health_check/service/impl/DoctorServiceImpl.java
+++ b/src/main/java/com/santt4na/health_check/service/impl/DoctorServiceImpl.java
@@ -9,6 +9,7 @@ import com.santt4na.health_check.mapper.DoctorMapper;
 import com.santt4na.health_check.repository.DoctorRepository;
 import com.santt4na.health_check.service.DoctorService;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,16 +19,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class DoctorServiceImpl implements DoctorService {
 	
 	private static final Logger logger = LoggerFactory.getLogger(Startup.class);
 	private static final Logger auditLogger = LoggerFactory.getLogger("audit");
 	
-	@Autowired
-	private DoctorMapper mapper;
+	private final DoctorMapper mapper;
 	
-	@Autowired
-	private DoctorRepository repository;
+	private final DoctorRepository repository;
 	
 	@Transactional
 	@Override

--- a/src/main/java/com/santt4na/health_check/service/impl/PatientServiceImpl.java
+++ b/src/main/java/com/santt4na/health_check/service/impl/PatientServiceImpl.java
@@ -9,6 +9,7 @@ import com.santt4na.health_check.mapper.PatientMapper;
 import com.santt4na.health_check.repository.PatientRepository;
 import com.santt4na.health_check.service.PatientService;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,16 +19,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class PatientServiceImpl implements PatientService {
 	
 	private static final Logger logger = LoggerFactory.getLogger(Startup.class);
 	private static final Logger auditLogger = LoggerFactory.getLogger("audit");
 	
-	@Autowired
-	private PatientMapper mapper;
+	private final PatientMapper mapper;
 	
-	@Autowired
-	private PatientRepository repository;
+	private final PatientRepository repository;
 	
 	@Transactional
 	@Override

--- a/src/main/java/com/santt4na/health_check/service/impl/ScheduleServiceImpl.java
+++ b/src/main/java/com/santt4na/health_check/service/impl/ScheduleServiceImpl.java
@@ -11,6 +11,7 @@ import com.santt4na.health_check.repository.DoctorRepository;
 import com.santt4na.health_check.repository.ScheduleRepository;
 import com.santt4na.health_check.service.ScheduleService;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 
@@ -18,18 +19,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class ScheduleServiceImpl implements ScheduleService {
 	
 	private final ScheduleRepository repository;
 	private final DoctorRepository doctorRepository;
 	private final ScheduleMapper mapper;
-	
-	public ScheduleServiceImpl(ScheduleRepository repository, DoctorRepository doctorRepository, ScheduleMapper mapper) {
-		this.repository = repository;
-		this.doctorRepository = doctorRepository;
-		this.mapper = mapper;
-	}
-	
+
 	@Transactional
 	public ScheduleResponseDTO createSchedule(ScheduleRequestDTO dto) {
 		Doctor doctor = doctorRepository.findById(dto.doctorId())


### PR DESCRIPTION
In this PR, I focused on improving the readability, consistency, and clean architecture principles of the codebase by making the following changes:

Removed boilerplate getters, setters, and default constructors from entities/POJOs
→ These were replaced with Lombok annotations such as @Getter, @Setter, @NoArgsConstructor to reduce noise and improve clarity.

Replaced field injection (@Autowired) with constructor injection using @RequiredArgsConstructor
→ This change improves testability by making dependencies explicit
→ Promotes immutability and final fields
→ Avoids hidden dependencies and potential NullPointerExceptions

 Replaced manual equals() and hashCode() implementations with Lombok’s @EqualsAndHashCode 